### PR TITLE
Fix null check for pendingResult in permission request handling

### DIFF
--- a/android/src/main/java/com/example/bluetooth_print_plus/bluetooth_print_plus/BluetoothPrintPlusPlugin.java
+++ b/android/src/main/java/com/example/bluetooth_print_plus/bluetooth_print_plus/BluetoothPrintPlusPlugin.java
@@ -365,8 +365,12 @@ public class BluetoothPrintPlusPlugin
       if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
         startScan();
       } else {
-        pendingResult.error("no_permissions", "this plugin requires location permissions for scanning", null);
-        pendingResult = null;
+        if (pendingResult != null) {
+          pendingResult.error("no_permissions", "this plugin requires location permissions for scanning", null);
+          pendingResult = null;
+        } else {
+          LogUtils.e(TAG, "pendingResult is null in onRequestPermissionsResult");
+        }
       }
       return true;
     }


### PR DESCRIPTION
This pull request adds improved error handling to the Bluetooth scanning permissions flow in the Android plugin. Specifically, it ensures that if the `pendingResult` is unexpectedly null when handling permission denial, an error is logged for easier debugging.

Error handling improvements:

* Added a check for a null `pendingResult` in the `onRequestPermissionsResult` method of `BluetoothPrintPlusPlugin.java`, and now logs an error message using `LogUtils.e` if it is null.